### PR TITLE
Support more `tex` embeded blocks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Alternately, if you would like to collaborate, I will happily add collaborators 
 
 ## Release Notes
 
+### [ 0.0.8 ]
+- Support syntax highlight in embedded blocks of `tex-preample` `tex-wrap-pre` `tex-wrap-post`
+
 ### [ 0.0.7 ]
 - Updated for Ott 0.29 error message format (see [#41](https://github.com/ott-lang/ott/pull/41))
 - Remove buggy postprocessing command

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "ott",
     "displayName": "ott",
     "description": "Ott formatting, typechecking, and syntax highlighting",
-    "version": "0.0.6",
+    "version": "0.0.8",
     "publisher": "JoeyEremondi",
     "repository": "https://github.com/JoeyEremondi/vscode-ott",
     "icon": "media/icon.png",
@@ -89,9 +89,9 @@
         "test": "npm run compile && node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {
-        "typescript": "^2.6.1",
-        "vscode": "^1.1.6",
-        "@types/node": "^7.0.43",
-        "@types/mocha": "^2.2.42"
+        "@types/mocha": "^2.2.42",
+        "@types/node": "^7.10.14",
+        "typescript": "^4.9.5",
+        "vscode": "^1.1.6"
     }
 }

--- a/syntaxes/ott.tmLanguage.json
+++ b/syntaxes/ott.tmLanguage.json
@@ -55,7 +55,7 @@
 			"patterns": [{
 					"name": "support.function.ott",
 					"contentName": "comment.ott",
-					"begin": "{{( )*(coq-equality|lex|repr-locally-nameless|phantom|texvar|isavar|holvar|ocamlvar|aux|lem|ihtexlong|order|isasyn|isaprec|lemwcf|coq-universe|tex-preamble|coq-lib|isa-auxfn-proof|isa-subrule-proof|isa-proof|com)",
+					"begin": "{{( )*(coq-equality|lex|repr-locally-nameless|phantom|texvar|isavar|holvar|ocamlvar|aux|lem|ihtexlong|order|isasyn|isaprec|lemwcf|coq-universe|coq-lib|isa-auxfn-proof|isa-subrule-proof|isa-proof|com)",
 					"end": "}}"
 				},
 				{
@@ -112,7 +112,7 @@
 			"patterns": [{
 				"name": "support.function.ott",
 				"contentName": "comment.ott",
-				"begin": "{{( )*(tex)",
+				"begin": "{{( )*(tex|tex-preamble|tex-wrap-pre|tex-wrap-post)",
 				"end": "}}",
 				"patterns": [{
 					"include": "text.tex.latex"


### PR DESCRIPTION
A tiny change to support more tex-style embed blocks.

Changes out of `ott.tmLanguage.json` are auxiliary.